### PR TITLE
Fix RSS feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,11 @@ plugins:
   - jekyll-feed
   - jekyll-seo-tag
 
+# Feed settings
+feed:
+  collections:
+    - essays
+
 # Exclude from processing
 exclude:
   - Gemfile


### PR DESCRIPTION
Configure the jekyll-feed plugin to include the  `essays` collection